### PR TITLE
fix to rvm/ruby setup

### DIFF
--- a/setup-osx.sh
+++ b/setup-osx.sh
@@ -144,7 +144,8 @@ if [ ! -x $HOME/.rvm/bin/rvm ]; then
   # brew install apple-gcc42 autoconf automake libtool libyaml libxml2 libxslt libksba openssl
   \curl -sSL https://get.rvm.io | bash -s stable
   source ~/.rvm/scripts/rvm
-  rvm install ruby-2.1-head
+  rvm requirements
+  rvm install 2.1
 fi
 
 # install vagrant


### PR DESCRIPTION
This fixes my earlier rvm error:

```
Exception `LoadError' at /Users/euf/.rvm/rubies/ruby-2.1-head/lib/ruby/2.1.0/rubygems.rb:1194 - cannot load such file -- rubygems/defaults/operating_system
Exception `LoadError' at /Users/euf/.rvm/rubies/ruby-2.1-head/lib/ruby/2.1.0/rubygems.rb:1203 - cannot load such file -- rubygems/defaults/ruby
ERROR:  While executing gem ... (Errno::ENOENT)
    No such file or directory @ dir_chdir - bundler/lib
```
